### PR TITLE
feat: add build-up play options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # FSA Goal Reporter
 
-A simple progressive web app for quickly composing soccer scoring messages for FSA games. Open `index.html` in a mobile browser, choose the scorer, assister, time, details, and goal location, then copy the generated message to share in your team chat.
+A simple progressive web app for quickly composing soccer scoring messages for FSA games. Open `index.html` in a mobile browser, choose the scorer, assister, time, build-up notes, details, and goal location, then copy the generated message to share in your team chat.
 
 The app works offline after the first load thanks to a service worker. Install it on your home screen for fast access during matches.

--- a/app.js
+++ b/app.js
@@ -43,12 +43,14 @@ document.getElementById('generate').addEventListener('click', () => {
   const time = document.getElementById('time').value;
   const details = document.getElementById('details').value;
   const location = selectedIndex !== null ? locationNames[selectedIndex] : '';
+  const buildUp = [...document.querySelectorAll('.playOption:checked')].map(o => o.value);
 
   let message = `🚨 FSA Goal! 🚨\n`;
   message += `⚽️ Scorer: ${scorer}\n`;
   message += `🅰️ Assisted By: ${assist || 'None'}\n`;
   if (time) message += `🕒 Time of Goal: ${time}‘\n`;
   if (location) message += `📍 Goal Location: ${location}\n`;
+  if (buildUp.length) message += `🔄 Build-Up: ${buildUp.join(', ')}\n`;
   if (details) message += `📝 Details: ${details}`;
 
   output.value = message.trim();

--- a/index.html
+++ b/index.html
@@ -25,6 +25,18 @@
         Time of Goal
         <input type="number" id="time" min="0" placeholder="Minute" />
       </label>
+      <fieldset id="playOptions">
+        <legend>Play Build-Up</legend>
+        <label><input type="checkbox" class="playOption" value="Breakaway" /> Breakaway</label>
+        <label><input type="checkbox" class="playOption" value="Rebound" /> Rebound</label>
+        <label><input type="checkbox" class="playOption" value="Throw-In" /> Throw-In</label>
+        <label><input type="checkbox" class="playOption" value="Through Pass" /> Through Pass</label>
+        <label><input type="checkbox" class="playOption" value="Counterattack" /> Counterattack</label>
+        <label><input type="checkbox" class="playOption" value="Corner Kick" /> Corner Kick</label>
+        <label><input type="checkbox" class="playOption" value="Free Kick" /> Free Kick</label>
+        <label><input type="checkbox" class="playOption" value="Penalty" /> Penalty</label>
+        <label><input type="checkbox" class="playOption" value="Cross" /> Cross</label>
+      </fieldset>
       <label>
         Details
         <textarea id="details" rows="2" placeholder="Details..."></textarea>

--- a/style.css
+++ b/style.css
@@ -89,3 +89,22 @@ button:active {
   color: #2196f3;
   min-height: 1.2rem;
 }
+
+#playOptions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 0.5rem;
+}
+
+#playOptions legend {
+  padding: 0 0.3rem;
+}
+
+#playOptions label {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.3rem;
+}


### PR DESCRIPTION
## Summary
- allow selecting goal build-up types (breakaway, throw-in, through pass, etc.)
- include selected build-up in generated chat message and copy to clipboard
- style the new checklist and update documentation

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be3ea8aae4832b931281f9704dfc42